### PR TITLE
[Feature] Rendering pipeline refactoring

### DIFF
--- a/app/src/main/java/ru/meatgames/tomb/domain/map/MapController.kt
+++ b/app/src/main/java/ru/meatgames/tomb/domain/map/MapController.kt
@@ -97,6 +97,7 @@ interface MapTerraformer {
 interface MapController {
     val mapFlow: StateFlow<MapState>
 
+    @Deprecated("Needs to be migrated to MapTile")
     fun getTile(
         coordinates: Coordinates,
     ): MapTileWrapper?

--- a/app/src/main/java/ru/meatgames/tomb/domain/map/MapScreenController.kt
+++ b/app/src/main/java/ru/meatgames/tomb/domain/map/MapScreenController.kt
@@ -20,6 +20,9 @@ import ru.meatgames.tomb.domain.enemy.EnemyAnimation
 import ru.meatgames.tomb.domain.enemy.EnemyId
 import ru.meatgames.tomb.domain.player.CharacterController
 import ru.meatgames.tomb.domain.player.CharacterState
+import ru.meatgames.tomb.domain.render.BUFFER_SIZE_MODIFIER
+import ru.meatgames.tomb.domain.render.BufferHolder
+import ru.meatgames.tomb.domain.render.BufferHolderFactory
 import ru.meatgames.tomb.domain.render.GameMapRenderPipeline
 import ru.meatgames.tomb.domain.render.computeFov
 import ru.meatgames.tomb.domain.turn.EnemyTurnResult
@@ -45,21 +48,14 @@ class MapScreenController @Inject constructor(
     private val tilesController: TilesController,
     private val gameMapRenderPipeline: GameMapRenderPipeline,
     private val gameController: GameController,
+    private val bufferHolderFactory: BufferHolderFactory,
 ) {
     
     private val characterRenderData = themeAssets.characterRenderData
     
     private val _state = MutableStateFlow<MapScreenState>(MapScreenState.Loading)
     val state: StateFlow<MapScreenState> = _state
-    
-    private val cachedVisibilityMask = BooleanArray(viewportWidth * viewportWidth) { false }
-    
-    private val preProcessingBufferSizeModifier: Int = 1
-    private val preProcessingViewportWidth: Int =
-        viewportWidth + 2 * preProcessingBufferSizeModifier
-    private val preProcessingViewportHeight: Int =
-        viewportHeight + 2 * preProcessingBufferSizeModifier
-    
+
     init {
         mapController.mapFlow
             .flatMapLatest { map ->
@@ -116,152 +112,136 @@ class MapScreenController @Inject constructor(
         if (characterState.position.x == -1 && characterState.position.y == -1) {
             return MapScreenState.Loading
         }
-        
-        val leftXCoordinate = characterState.position.x - preProcessingViewportWidth / 2
-        val topYCoordinate = characterState.position.y - preProcessingViewportHeight / 2
-        val viewportZeroPosition =
-            (leftXCoordinate + preProcessingBufferSizeModifier) to (topYCoordinate + preProcessingBufferSizeModifier)
-        
-        val reducedTiles = reduceToViewportSize(
-            leftXCoordinate = leftXCoordinate,
-            topYCoordinate = topYCoordinate,
+
+        val bufferHolder = bufferHolderFactory.get(viewportWidth, viewportHeight)
+
+        bufferHolder.clear()
+
+        bufferHolder.horizontalOffset = characterState.position.x - bufferHolder.horizontalCenter
+        bufferHolder.verticalOffset = characterState.position.y - bufferHolder.verticalCenter
+
+        bufferHolder.fillMapBuffer(
+            tiles = this,
             mapWidth = mapWidth,
             mapHeight = mapHeight,
-        ).also {
-            it.calculateFov(
-                viewportWidth = viewportWidth,
-                viewportHeight = viewportHeight,
-            )
-        }
-        
-        val pipelineRenderData = gameMapRenderPipeline.run(
-            tiles = reducedTiles,
-            tilesLineWidth = preProcessingViewportWidth,
-            startCoordinates = characterState.position.x - viewportWidth / 2 to characterState.position.y - viewportHeight / 2,
-            shouldRenderTile = { index ->
-                cachedVisibilityMask[index]
-            },
         )
-        
-        val tileToFadeIn = pipelineRenderData.tilesToFadeIn.toSet()
-        val tileToFadeOut = pipelineRenderData.tilesToFadeOut.toSet()
-        
+
+        bufferHolder.calculateFov()
+
+        val renderData = gameMapRenderPipeline.run()
+
+        val tileToFadeIn = renderData.tilesToFadeIn.toSet()
+        val tileToFadeOut = renderData.tilesToFadeOut.toSet()
+
         return MapScreenState.Ready(
-            tilesWidth = preProcessingViewportWidth,
+            tilesWidth = bufferHolder.width,
             viewportWidth = viewportWidth,
             viewportHeight = viewportHeight,
-            tilesPadding = preProcessingBufferSizeModifier,
-            tiles = pipelineRenderData.tiles,
+            tilesPadding = BUFFER_SIZE_MODIFIER,
+            tiles = renderData.tiles,
             tilesToFadeIn = tileToFadeIn,
             tilesToFadeOut = tileToFadeOut,
             characterRenderData = characterRenderData,
             playerHealth = characterState.health,
             turnResultsToAnimate = gameState.toMapScreenCharacterAnimations(
-                viewportZeroPosition = viewportZeroPosition,
+                bufferHolder = bufferHolder,
+                viewportZeroPosition = bufferHolder.horizontalOffset to bufferHolder.verticalOffset,
                 viewportWidth = viewportWidth,
             ),
         )
     }
-    
-    private fun List<MapTileWrapper?>.calculateFov(
-        viewportWidth: Int,
-        viewportHeight: Int,
-    ) {
-        cachedVisibilityMask.updateVisibilityMask()
-        
-        val characterScreenSpaceX = viewportWidth / 2
-        val characterScreenSpaceY = viewportHeight / 2
-        
+
+    private fun BufferHolder.calculateFov() {
+        visibilityBuffer.fill(false)
+
         computeFov(
-            originX = characterScreenSpaceX,
-            originY = characterScreenSpaceY,
-            maxDepth = viewportWidth / 2 + 1,
-            revealTile = { x, y -> cachedVisibilityMask[x + y * viewportWidth] = true },
+            originX = horizontalCenter,
+            originY = verticalCenter,
+            maxDepth = horizontalCenter + 1,
+            revealTile = { x, y -> visibilityBuffer[x + y * width] = true },
             checkIfTileIsBlocking = { x, y ->
-                val index = (x + 1) + (y + 1) * preProcessingViewportWidth
-                val objectEntity = this[index]?.tile?.objectEntityTile ?: return@computeFov false
+                val index = x + y * width
+                val objectEntity = mapBuffer[index]?.objectEntityTile ?: return@computeFov false
                 !tilesController.isObjectEntityVisibleThrough(
                     objectEntity = objectEntity,
                 )
             }
         )
+
+        for (i in 0 until width) {
+            visibilityBuffer[i] = false
+            visibilityBuffer[(height - 1) * width + i] = false
+        }
+
+        for (i in 0 until height) {
+            visibilityBuffer[i * width] = false
+            visibilityBuffer[(i + 1) * width - 1] = false
+        }
     }
-    
-    private fun BooleanArray.updateVisibilityMask() {
-        fill(false)
-    }
-    
-    private fun List<MapTile>.reduceToViewportSize(
-        leftXCoordinate: Int,
-        topYCoordinate: Int,
+
+    private fun BufferHolder.fillMapBuffer(
+        tiles: List<MapTile>,
         mapWidth: Int,
         mapHeight: Int,
-    ): List<MapTileWrapper?> = (0 until preProcessingViewportHeight).map { line ->
-        val start = (topYCoordinate + line) * mapWidth + leftXCoordinate
-        val end = start + preProcessingViewportWidth
-        when {
-            topYCoordinate + line !in 0 until mapHeight -> {
-                List(preProcessingViewportWidth) { null }
-            }
-            
-            leftXCoordinate < 0 -> {
-                List(preProcessingViewportWidth) { index ->
-                    val tileIndex = start + index
-                    when {
-                        leftXCoordinate + index < 0 -> null
-                        else -> this[tileIndex]
-                    }?.toMapTileWrapper(
-                        tileIndex = tileIndex,
-                        mapWidth = mapWidth,
+    ) {
+        (0 until height).map { line ->
+            val start = (verticalOffset + line) * mapWidth + horizontalOffset
+
+            (0 until width).map { index ->
+
+                val tileIndex = start + index
+
+                val tile = when {
+                    verticalOffset + line !in 0 until mapHeight -> {
+                        null
+                    }
+
+                    horizontalOffset < 0 -> {
+                        when {
+                            horizontalOffset + index < 0 -> null
+                            else -> tiles[tileIndex]
+                        }
+                    }
+
+                    horizontalOffset + width > mapWidth -> {
+                        when {
+                            horizontalOffset + index < mapWidth -> tiles[tileIndex]
+                            else -> null
+                        }
+                    }
+
+                    else -> {
+                        tiles[start + index]
+                    }
+                }
+
+                tile?.let {
+                    mapBuffer.set(
+                        index = line * width + index,
+                        value = it,
                     )
                 }
-            }
-            
-            leftXCoordinate + preProcessingViewportWidth > mapWidth -> {
-                List(preProcessingViewportWidth) { index ->
-                    val tileIndex = start + index
-                    when {
-                        leftXCoordinate + index < mapWidth -> this[tileIndex]
-                        else -> null
-                    }?.toMapTileWrapper(
-                        tileIndex = tileIndex,
-                        mapWidth = mapWidth,
-                    )
-                }
-            }
-            
-            else -> this.subList(start, end).mapIndexed { index, tile ->
-                tile.toMapTileWrapper(
-                    tileIndex = start + index,
-                    mapWidth = mapWidth,
-                )
             }
         }
-    }.fold(emptyList()) { acc, item -> acc + item }
-    
-    private fun MapTile.toMapTileWrapper(
-        tileIndex: Int,
-        mapWidth: Int,
-    ): MapTileWrapper = MapTileWrapper(
-        x = tileIndex % mapWidth,
-        y = tileIndex / mapWidth,
-        tile = this,
-    )
-    
+    }
+
     private fun GameState.toMapScreenCharacterAnimations(
+        bufferHolder: BufferHolder,
         viewportWidth: Int,
         viewportZeroPosition: Coordinates,
     ): MapScreenCharacterAnimations? = when (this) {
         is GameState.AnimatingCharacter -> {
             MapScreenCharacterAnimations.Player(turnResult)
         }
-        
+
         is GameState.AnimatingEnemies -> {
             MapScreenCharacterAnimations.Enemies(
                 results.filterNonVisibleAnimations(
+                    bufferHolder = bufferHolder,
                     viewportWidth = viewportWidth,
                     viewportZeroPosition = viewportZeroPosition,
                 ).toEnemiesAnimations(
+                    bufferHolder = bufferHolder,
                     viewportWidth = viewportWidth,
                     viewportZeroPosition = viewportZeroPosition,
                 ),
@@ -274,6 +254,7 @@ class MapScreenController @Inject constructor(
     }
     
     private fun List<EnemyTurnResult>.filterNonVisibleAnimations(
+        bufferHolder: BufferHolder,
         viewportZeroPosition: Coordinates,
         viewportWidth: Int,
     ): List<EnemyTurnResult> = filter { result ->
@@ -287,10 +268,11 @@ class MapScreenController @Inject constructor(
             
             else -> listOf(result.position - viewportZeroPosition)
         }.filter { (x, y) -> x in 0 until viewportWidth && y in 0 until viewportHeight }
-            .any { (x, y) -> cachedVisibilityMask[x + y * viewportWidth] }
+            .any { (x, y) -> bufferHolder.visibilityBuffer[x + y * viewportWidth] }
     }
     
     private fun List<EnemyTurnResult>.toEnemiesAnimations(
+        bufferHolder: BufferHolder,
         viewportZeroPosition: Coordinates,
         viewportWidth: Int,
     ): EnemiesAnimations = map { result ->
@@ -300,15 +282,15 @@ class MapScreenController @Inject constructor(
                 val currentScreenSpaceIndex =
                     currentScreenSpacePosition.first + currentScreenSpacePosition.second * viewportWidth
                 val currentTileVisibility =
-                    cachedVisibilityMask.getOrElse(currentScreenSpaceIndex) { false }
-                
+                    bufferHolder.visibilityBuffer.getOrElse(currentScreenSpaceIndex) { false }
+
                 val nextScreenSpacePosition =
                     currentScreenSpacePosition + result.direction.resolvedOffset
                 val nextScreenSpaceIndex =
                     nextScreenSpacePosition.first + nextScreenSpacePosition.second * viewportWidth
                 val nextTileVisibility =
-                    cachedVisibilityMask.getOrElse(nextScreenSpaceIndex) { false }
-                
+                    bufferHolder.visibilityBuffer.getOrElse(nextScreenSpaceIndex) { false }
+
                 result.enemyId to EnemyAnimation.Move(
                     direction = result.direction,
                     fade = when {

--- a/app/src/main/java/ru/meatgames/tomb/domain/map/MapTile.kt
+++ b/app/src/main/java/ru/meatgames/tomb/domain/map/MapTile.kt
@@ -17,6 +17,7 @@ data class MapTile(
 
 }
 
+@Deprecated("Migrate to MapTile")
 data class MapTileWrapper(
     val x: Int,
     val y: Int,

--- a/app/src/main/java/ru/meatgames/tomb/domain/render/BufferHolder.kt
+++ b/app/src/main/java/ru/meatgames/tomb/domain/render/BufferHolder.kt
@@ -1,0 +1,64 @@
+package ru.meatgames.tomb.domain.render
+
+import ru.meatgames.tomb.domain.map.MapTile
+import ru.meatgames.tomb.model.tile.domain.FloorRenderTile
+import ru.meatgames.tomb.model.tile.domain.ObjectRenderTile
+import ru.meatgames.tomb.render.MapRenderTile
+import javax.inject.Inject
+import javax.inject.Singleton
+
+const val BUFFER_SIZE_MODIFIER: Int = 1
+
+class BufferHolder(
+    viewportWidth: Int,
+    viewportHeight: Int,
+) {
+
+    val width: Int = viewportWidth + BUFFER_SIZE_MODIFIER * 2
+    val height: Int = viewportHeight + BUFFER_SIZE_MODIFIER * 2
+
+    val horizontalCenter = width / 2
+    val verticalCenter = height / 2
+
+    private val size: Int = width * height
+
+    var horizontalOffset: Int = 0
+    var verticalOffset: Int = 0
+
+    val mapBuffer: Array<MapTile?> = Array(size) { null }
+    val visibilityBuffer: BooleanArray = BooleanArray(size) { false }
+    val floorRenderingBuffer: Array<FloorRenderTile?> = Array(size) { null }
+    val objectRenderingBuffer: Array<ObjectRenderTile?> = Array(size) { null }
+    val resultRenderingBuffer: Array<MapRenderTile> = Array(size) { MapRenderTile.Empty }
+
+    fun clear() {
+        mapBuffer.fill(null)
+        visibilityBuffer.fill(true)
+        floorRenderingBuffer.fill(null)
+        objectRenderingBuffer.fill(null)
+        resultRenderingBuffer.fill(MapRenderTile.Empty)
+    }
+
+}
+
+@Singleton
+class BufferHolderFactory @Inject constructor() {
+
+    private var _cachedBufferHolder: BufferHolder? = null
+    val cachedBufferHolder: BufferHolder
+        get() {
+            val bufferHolder = _cachedBufferHolder
+            require(bufferHolder != null) { "BufferHolder needs to be initialized first" }
+            return bufferHolder
+        }
+
+    fun get(
+        viewportWidth: Int,
+        viewportHeight: Int,
+    ): BufferHolder {
+        return _cachedBufferHolder
+            ?.takeIf { viewportWidth + BUFFER_SIZE_MODIFIER == it.width && viewportHeight + BUFFER_SIZE_MODIFIER == it.height }
+            ?: let { BufferHolder(viewportWidth, viewportHeight).also { _cachedBufferHolder = it } }
+    }
+
+}

--- a/app/src/main/java/ru/meatgames/tomb/domain/render/GameMapRenderPipeline.kt
+++ b/app/src/main/java/ru/meatgames/tomb/domain/render/GameMapRenderPipeline.kt
@@ -11,8 +11,8 @@ import ru.meatgames.tomb.model.tile.domain.FloorRenderTile
 import ru.meatgames.tomb.model.tile.domain.ObjectRenderTile
 import ru.meatgames.tomb.render.MapRenderTile
 import ru.meatgames.tomb.render.RenderData
-import ru.meatgames.tomb.domain.map.MapTileWrapper
 import ru.meatgames.tomb.model.theme.ASSETS_TILE_SIZE
+import ru.meatgames.tomb.model.tile.domain.ObjectEntityTile
 import javax.inject.Inject
 
 class GameMapRenderPipeline @Inject constructor(
@@ -20,93 +20,85 @@ class GameMapRenderPipeline @Inject constructor(
     private val decoratorsPipeline: MapDecoratorPipeline,
     private val itemsHolder: ItemsHolder,
     private val enemiesHolder: EnemiesHolder,
+    private val bufferHolderFactory: BufferHolderFactory,
 ) {
-    
-    private var prevTiles = setOf<Coordinates>()
-    
-    // Assumes tiles is a square
-    fun run(
-        tiles: List<MapTileWrapper?>,
-        tilesLineWidth: Int,
-        startCoordinates: Coordinates,
-        shouldRenderTile: (Int) -> Boolean,
-    ): GameMapPipelineRenderData {
-        val renderTiles = decoratorsPipeline.produceRenderTilesFrom(
-            tiles = tiles,
-            tilesLineWidth = tilesLineWidth,
-        )
-        
-        val processedRenderTiles = renderTiles.applyFOV(
-            tilesLineWidth,
-            shouldRenderTile,
-        )
-        
+
+    private var previousVisibleTiles = setOf<Coordinates>()
+
+    fun run(): GameMapPipelineRenderData {
+        val bufferHolder = bufferHolderFactory.cachedBufferHolder
+
+        decoratorsPipeline.produceRenderTilesFrom()
+
+        bufferHolder.resolveResultRenderingBuffer()
+
         val tilesToReveal = mutableSetOf<ScreenSpaceCoordinates>()
         val tilesToFade = mutableSetOf<ScreenSpaceCoordinates>()
-        
-        fun MapTileWrapper.toCoordinates() = x to y
-        
-        processedRenderTiles.forEach { mapRenderTile ->
-            val newRenderTile = mapRenderTile.second
-            val tileWrapper = mapRenderTile.first ?: return@forEach
-            
-            val previousTileWasVisible = prevTiles.contains(tileWrapper.toCoordinates())
-            
-            val isCurrentTileVisible = (newRenderTile as? MapRenderTile.Content)?.isVisible ?: false
-            
-            if (previousTileWasVisible && !isCurrentTileVisible) {
-                tilesToFade.add(tileWrapper.x - startCoordinates.first to tileWrapper.y - startCoordinates.second)
+
+        bufferHolder.resultRenderingBuffer.forEachIndexed { index, mapRenderTile ->
+            if (mapRenderTile !is MapRenderTile.Content) return@forEachIndexed
+
+            val x = index % bufferHolder.width
+            val y = index / bufferHolder.width
+            val coordinates =
+                (bufferHolder.horizontalOffset + x) to (bufferHolder.verticalOffset + y)
+
+            val previousTileWasVisible = previousVisibleTiles.contains(coordinates)
+            val currentTileVisible = mapRenderTile.isVisible
+
+            if (previousTileWasVisible && !currentTileVisible) {
+                tilesToFade.add(coordinates)
             }
-            if (!previousTileWasVisible && isCurrentTileVisible) {
-                tilesToReveal.add(tileWrapper.x - startCoordinates.first to tileWrapper.y - startCoordinates.second)
+            if (!previousTileWasVisible && currentTileVisible) {
+                tilesToReveal.add(coordinates)
             }
         }
-        
-        prevTiles = processedRenderTiles.filter { it.first != null }
-            .filter { (it.second as? MapRenderTile.Content)?.isVisible == true }
-            .map { it.first!!.toCoordinates() }
-            .toSet()
-        
+
+        previousVisibleTiles = bufferHolder.resultRenderingBuffer.mapIndexedNotNull { index, tile ->
+            if (tile !is MapRenderTile.Content) return@mapIndexedNotNull null
+            if (!tile.isVisible) return@mapIndexedNotNull null
+
+            val x = index % bufferHolder.width
+            val y = index / bufferHolder.width
+            (bufferHolder.horizontalOffset + x) to (bufferHolder.verticalOffset + y)
+        }.toSet()
+
         return GameMapPipelineRenderData(
-            tiles = processedRenderTiles.map { it.second },
+            tiles = bufferHolder.resultRenderingBuffer.toList(),
             tilesToFadeIn = tilesToReveal.toList(),
             tilesToFadeOut = tilesToFade.toList(),
         )
     }
-    
-    private fun List<ScreenSpaceRenderTiles?>.applyFOV(
-        tilesLineWidth: Int,
-        shouldRenderTile: (Int) -> Boolean,
-    ): List<ScreenSpaceMapRenderTile> = mapIndexed { index, pair ->
-        when (pair) {
-            null -> null to MapRenderTile.Empty
-            else -> {
-                val x = index % tilesLineWidth
-                val y = index / tilesLineWidth
-                
-                // border tiles needs to be skipped as they are not rendered
-                val isVisible = if (x == 0 || x == tilesLineWidth - 1 || y == 0 || y == tilesLineWidth - 1) {
-                    false
-                } else {
-                    shouldRenderTile((y - 1) * (tilesLineWidth - 2) + x - 1)
-                }
-                
-                val coordinates = pair.first.x to pair.first.y
-                val enemy = enemiesHolder.getEnemy(coordinates)
-                val tileAbove = getOrNull(index - tilesLineWidth)?.second
-                
-                pair.first to MapRenderTile.Content(
-                    floorData = pair.second.first.toFloorRenderTileData(),
-                    objectData = pair.second.second?.toObjectRenderTileData(),
-                    itemData = itemsHolder.getItemContainer(coordinates)
-                        ?.let { themeAssets.resolveItemRenderData() },
-                    enemyData = enemy?.let { themeAssets.getEnemyRenderData(it) },
-                    isVisible = isVisible,
-                    decorations = tileAbove?.takeIf { it.second?.hasBottomShadow() == true }
-                        ?.let { listOf(themeAssets.resolveBottomShadow()) }
-                        ?: emptyList(),
-                )
+
+    private fun BufferHolder.resolveResultRenderingBuffer() {
+        for (index in 0 until width * height) {
+            val x = index % width
+            val y = index / width
+
+            val floorRenderTile = floorRenderingBuffer[index]
+            val objectRenderTile = objectRenderingBuffer[index]
+
+            if (floorRenderTile == null) {
+                resultRenderingBuffer[index] = MapRenderTile.Empty
+                continue
             }
+
+            val coordinates = (horizontalOffset + x) to (verticalOffset + y)
+
+            val enemy = enemiesHolder.getEnemy(coordinates)
+            val objectAbove = mapBuffer.getOrNull(index - width)?.objectEntityTile
+
+            resultRenderingBuffer[index] = MapRenderTile.Content(
+                floorData = floorRenderTile.toFloorRenderTileData(),
+                objectData = objectRenderTile?.toObjectRenderTileData(),
+                itemData = itemsHolder.getItemContainer(coordinates)
+                    ?.let { themeAssets.resolveItemRenderData() },
+                enemyData = enemy?.let { themeAssets.getEnemyRenderData(it) },
+                isVisible = visibilityBuffer[index],
+                decorations = objectAbove?.takeIf { it.hasBottomShadow() == true }
+                    ?.let { listOf(themeAssets.resolveBottomShadow()) }
+                    ?: emptyList(),
+            )
         }
     }
     
@@ -129,24 +121,9 @@ class GameMapRenderPipeline @Inject constructor(
     
 }
 
-internal fun ObjectRenderTile.hasBottomShadow(): Boolean = when (this) {
-    ObjectRenderTile.DoorClosed,
-    ObjectRenderTile.StairsUp,
-    ObjectRenderTile.Wall0,
-    ObjectRenderTile.Wall1,
-    ObjectRenderTile.Wall2,
-    ObjectRenderTile.Wall3,
-    ObjectRenderTile.Wall4,
-    ObjectRenderTile.Wall5,
-    ObjectRenderTile.Wall6,
-    ObjectRenderTile.Wall7,
-    ObjectRenderTile.Wall8,
-    ObjectRenderTile.Wall9,
-    ObjectRenderTile.Wall10,
-    ObjectRenderTile.Wall11,
-    ObjectRenderTile.Wall12,
-    ObjectRenderTile.Wall13,
-    ObjectRenderTile.Wall14,
-    ObjectRenderTile.Wall15 -> true
+internal fun ObjectEntityTile.hasBottomShadow(): Boolean = when (this) {
+    ObjectEntityTile.DoorClosed,
+    ObjectEntityTile.StairsUp,
+    ObjectEntityTile.Wall -> true
     else -> false
 }

--- a/app/src/main/java/ru/meatgames/tomb/domain/render/MapDecoratorPipeline.kt
+++ b/app/src/main/java/ru/meatgames/tomb/domain/render/MapDecoratorPipeline.kt
@@ -1,6 +1,5 @@
 package ru.meatgames.tomb.domain.render
 
-import ru.meatgames.tomb.domain.map.MapTileWrapper
 import ru.meatgames.tomb.model.tile.domain.FloorEntityTile
 import ru.meatgames.tomb.model.tile.domain.FloorRenderTile
 import ru.meatgames.tomb.model.tile.domain.ObjectEntityTile
@@ -10,28 +9,24 @@ import javax.inject.Inject
 
 class MapDecoratorPipeline @Inject constructor(
     private val mapDecorators: Set<@JvmSuppressWildcards MapRenderTilesDecorator>,
+    private val bufferHolderFactory: BufferHolderFactory,
 ) {
 
     // Assumes tiles is a square
-    fun produceRenderTilesFrom(
-        tiles: List<MapTileWrapper?>,
-        tilesLineWidth: Int,
-    ): List<ScreenSpaceRenderTiles?> = tiles.mapToRenderTiles()
-        .applyDecorators(tilesLineWidth)
+    fun produceRenderTilesFrom() {
+        bufferHolderFactory.cachedBufferHolder.fillRenderingBuffers()
 
-    private fun List<MapTileWrapper?>.mapToRenderTiles(): List<ScreenSpaceRenderTiles?> = map {
-        val tile = it?.tile ?: return@map null
-        it to RenderTiles(
-            first = tile.floorEntityTile.toFloorRenderTile(),
-            second = tile.objectEntityTile?.toObjectRenderTile(),
-        )
+        mapDecorators.forEach { decorator ->
+            decorator.apply()
+        }
     }
-    
-    private fun List<ScreenSpaceRenderTiles?>.applyDecorators(
-        tilesLineWidth: Int,
-    ): List<ScreenSpaceRenderTiles?> = run {
-        mapDecorators.fold(this) { tiles, decorator ->
-            decorator.processMapRenderTiles(tiles, tilesLineWidth)
+
+    private fun BufferHolder.fillRenderingBuffers() {
+        var index = -1
+        mapBuffer.iterator().forEach {
+            index++
+            floorRenderingBuffer[index] = it?.floorEntityTile?.toFloorRenderTile()
+            objectRenderingBuffer[index] = it?.objectEntityTile?.toObjectRenderTile()
         }
     }
 

--- a/app/src/main/java/ru/meatgames/tomb/domain/render/RoomPreviewRenderDataAssembler.kt
+++ b/app/src/main/java/ru/meatgames/tomb/domain/render/RoomPreviewRenderDataAssembler.kt
@@ -2,7 +2,7 @@ package ru.meatgames.tomb.domain.render
 
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.unit.IntOffset
-import ru.meatgames.tomb.domain.map.MapTileWrapper
+import ru.meatgames.tomb.domain.map.MapTile
 import ru.meatgames.tomb.model.theme.ASSETS_TILE_SIZE
 import ru.meatgames.tomb.model.theme.ThemeAssets
 import ru.meatgames.tomb.model.tile.domain.FloorEntityTile
@@ -12,46 +12,51 @@ import ru.meatgames.tomb.model.tile.domain.ObjectRenderTile
 import ru.meatgames.tomb.render.MapRenderTile
 import ru.meatgames.tomb.render.MapRenderTilesDecorator
 import ru.meatgames.tomb.render.RenderData
-import javax.inject.Inject
 
-class RoomPreviewRenderProcessor @Inject constructor(
+class RoomPreviewRenderDataAssembler(
     private val themeAssets: ThemeAssets,
     private val mapDecorators: Set<@JvmSuppressWildcards MapRenderTilesDecorator>,
+    private val bufferHolder: BufferHolder,
 ) {
-    
-    // Assumes tiles is a square
-    fun produceRenderTilesFrom(
-        tiles: List<MapTileWrapper?>,
-        tilesLineWidth: Int,
-    ): List<ScreenSpaceMapRenderTile> = tiles.mapToRenderTiles()
-        .applyDecorators(tilesLineWidth)
-        .revealAllTiles()
-    
-    private fun List<MapTileWrapper?>.mapToRenderTiles(): List<ScreenSpaceRenderTiles?> = map {
-        it ?: return@map null
-        it to RenderTiles(
-            first = it.tile.floorEntityTile.toFloorRenderTile(),
-            second = it.tile.objectEntityTile?.toObjectRenderTile(),
-        )
-    }
-    
-    private fun List<ScreenSpaceRenderTiles?>.applyDecorators(
-        tilesLineWidth: Int,
-    ): List<ScreenSpaceRenderTiles?> = run {
-        mapDecorators.fold(this) { tiles, decorator ->
-            decorator.processMapRenderTiles(tiles, tilesLineWidth)
+
+    fun run(
+        tiles: List<MapTile>,
+    ) {
+        tiles.forEachIndexed { index, tile ->
+            bufferHolder.mapBuffer[index] = tile
+            bufferHolder.floorRenderingBuffer[index] = tile.floorEntityTile.toFloorRenderTile()
+            bufferHolder.objectRenderingBuffer[index] = tile.objectEntityTile?.toObjectRenderTile()
         }
+
+        mapDecorators.forEach { decorator ->
+            decorator.apply()
+        }
+
+        bufferHolder.visibilityBuffer.fill(true)
+        bufferHolder.resolveResultRenderingBuffer()
     }
-    
-    private fun List<ScreenSpaceRenderTiles?>.revealAllTiles(): List<ScreenSpaceMapRenderTile> = map { pair ->
-        when (pair) {
-            null -> null to MapRenderTile.Empty
-            else -> pair.first to MapRenderTile.Content(
-                floorData = pair.second.first.toFloorRenderTileData(),
-                objectData = pair.second.second?.toObjectRenderTileData(),
+
+    private fun BufferHolder.resolveResultRenderingBuffer() {
+        for (index in 0 until width * height) {
+            val floorRenderTile = floorRenderingBuffer[index]
+            val objectRenderTile = objectRenderingBuffer[index]
+
+            if (floorRenderTile == null) {
+                resultRenderingBuffer[index] = MapRenderTile.Empty
+                continue
+            }
+
+            val objectAbove = mapBuffer.getOrNull(index - width)?.objectEntityTile
+
+            resultRenderingBuffer[index] = MapRenderTile.Content(
+                floorData = floorRenderTile.toFloorRenderTileData(),
+                objectData = objectRenderTile?.toObjectRenderTileData(),
                 itemData = null,
                 enemyData = null,
-                isVisible = true,
+                isVisible = visibilityBuffer[index],
+                decorations = objectAbove?.takeIf { it.hasBottomShadow() == true }
+                    ?.let { listOf(themeAssets.resolveBottomShadow()) }
+                    ?: emptyList(),
             )
         }
     }

--- a/app/src/main/java/ru/meatgames/tomb/render/MapRenderTilesDecorator.kt
+++ b/app/src/main/java/ru/meatgames/tomb/render/MapRenderTilesDecorator.kt
@@ -1,12 +1,7 @@
 package ru.meatgames.tomb.render
 
-import ru.meatgames.tomb.domain.render.ScreenSpaceRenderTiles
-
 interface MapRenderTilesDecorator {
 
-    fun processMapRenderTiles(
-        mapRenderTiles: List<ScreenSpaceRenderTiles?>,
-        tileLineWidth: Int,
-    ): List<ScreenSpaceRenderTiles?>
+    fun apply()
 
 }

--- a/app/src/main/java/ru/meatgames/tomb/render/WallsDecorator.kt
+++ b/app/src/main/java/ru/meatgames/tomb/render/WallsDecorator.kt
@@ -1,69 +1,74 @@
 package ru.meatgames.tomb.render
 
-import ru.meatgames.tomb.domain.render.RenderTiles
-import ru.meatgames.tomb.domain.render.ScreenSpaceRenderTiles
+import ru.meatgames.tomb.domain.render.BufferHolder
+import ru.meatgames.tomb.domain.render.BufferHolderFactory
+import ru.meatgames.tomb.model.tile.domain.ObjectEntityTile
 import ru.meatgames.tomb.model.tile.domain.ObjectRenderTile
 import javax.inject.Inject
 
-class WallsDecorator @Inject constructor() : MapRenderTilesDecorator {
-    
-    override fun processMapRenderTiles(
-        mapRenderTiles: List<ScreenSpaceRenderTiles?>,
-        tileLineWidth: Int,
-    ): List<ScreenSpaceRenderTiles?> = mapRenderTiles.mapIndexed { index, pair ->
-        val objectRenderTile = pair?.second?.second ?: return@mapIndexed pair
-        if (!objectRenderTile.isWall()) return@mapIndexed pair
+class WallsDecorator @Inject constructor(
+    private val bufferHolderFactory: BufferHolderFactory,
+) : MapRenderTilesDecorator {
 
-        val updatedWallRenderTile = mapRenderTiles.calcWallsFlags(index, tileLineWidth)
-            .filterAngles(index, tileLineWidth, mapRenderTiles.size)
-        
-        pair.first to RenderTiles(pair.second.first, updatedWallRenderTile)
+    override fun apply() {
+        val bufferHolder = bufferHolderFactory.cachedBufferHolder
+
+        var index = -1
+
+        bufferHolder.mapBuffer.iterator().forEach { tile ->
+            index++
+
+            if (!bufferHolder.visibilityBuffer[index]) return@forEach
+            val objectEntityTile = tile?.objectEntityTile ?: return@forEach
+            if (!objectEntityTile.isWall()) return@forEach
+
+            val wallFlags = bufferHolder.calcWallsFlags(index)
+            bufferHolder.filterAngles(
+                wallFlags = wallFlags,
+                index = index,
+            )
+        }
     }
 
-    private fun List<ScreenSpaceRenderTiles?>.calcWallsFlags(
-        tileIndex: Int,
-        tilesLineWidth: Int,
+    private fun BufferHolder.calcWallsFlags(
+        index: Int,
     ): Int {
         var wallFlags = 0
 
         // Top
-        if (getOrNull(tileIndex - tilesLineWidth)?.second?.second?.isWall() == true) {
+        if (mapBuffer.getOrNull(index - width)?.objectEntityTile?.isWall() == true) {
             wallFlags += 1
         }
         // Right
-        if (getOrNull(tileIndex + 1)?.second?.second?.isWall() == true) {
+        if (mapBuffer.getOrNull(index + 1)?.objectEntityTile?.isWall() == true) {
             wallFlags += 2
         }
         // Bottom
-        if (getOrNull(tileIndex + tilesLineWidth)?.second?.second?.isWall() == true) {
+        if (mapBuffer.getOrNull(index + width)?.objectEntityTile?.isWall() == true) {
             wallFlags += 4
         }
         // Left
-        if (getOrNull(tileIndex - 1)?.second?.second?.isWall() == true) {
+        if (mapBuffer.getOrNull(index - 1)?.objectEntityTile?.isWall() == true) {
             wallFlags += 8
         }
 
         return wallFlags
     }
 
-    private fun Int.filterAngles(
-        tileIndex: Int,
-        tilesLineWidth: Int,
-        maxIndex: Int
-    ): ObjectRenderTile {
-        val wallRenderTile = toWallRenderTile()
+    private fun BufferHolder.filterAngles(
+        wallFlags: Int,
+        index: Int,
+    ) {
+        val wallRenderTile = wallFlags.toWallRenderTile()
 
-        val x = tileIndex % tilesLineWidth
-        val verticalMiddlePoint = tilesLineWidth / 2
+        val x = index % width
+        val y = index / width
 
-        val y = tileIndex / tilesLineWidth
-        val horizontalMiddlePoint = maxIndex / tilesLineWidth / 2
+        val deltaX = (x - horizontalCenter).coerceIn(minimumValue = -1, maximumValue = 1)
+        val deltaY = (y - verticalCenter).coerceIn(minimumValue = -1, maximumValue = 1)
 
-        val deltaX = (x - verticalMiddlePoint).coerceIn(minimumValue = -1, maximumValue = 1)
-        val deltaY = (y - horizontalMiddlePoint).coerceIn(minimumValue = -1, maximumValue = 1)
-
-        return when (wallRenderTile) {
-            ObjectRenderTile.Wall15 -> (this - calcFilterForWall15(deltaX = deltaX, deltaY = deltaY)).toWallRenderTile()
+        objectRenderingBuffer[index] = when (wallRenderTile) {
+            ObjectRenderTile.Wall15 -> (wallFlags - calcFilterForWall15(deltaX = deltaX, deltaY = deltaY)).toWallRenderTile()
             ObjectRenderTile.Wall7 -> filterWall7(deltaX = deltaX, deltaY = deltaY)
             ObjectRenderTile.Wall11 -> filterWall11(deltaX = deltaX, deltaY = deltaY)
             ObjectRenderTile.Wall14 -> filterWall14(deltaX = deltaX, deltaY = deltaY)
@@ -179,23 +184,8 @@ class WallsDecorator @Inject constructor() : MapRenderTilesDecorator {
         else -> throw IllegalArgumentException("Unknown wall flags value: $this")
     }
 
-    private fun ObjectRenderTile.isWall(): Boolean = when (this) {
-        ObjectRenderTile.Wall0,
-        ObjectRenderTile.Wall1,
-        ObjectRenderTile.Wall2,
-        ObjectRenderTile.Wall3,
-        ObjectRenderTile.Wall4,
-        ObjectRenderTile.Wall5,
-        ObjectRenderTile.Wall6,
-        ObjectRenderTile.Wall7,
-        ObjectRenderTile.Wall8,
-        ObjectRenderTile.Wall9,
-        ObjectRenderTile.Wall10,
-        ObjectRenderTile.Wall11,
-        ObjectRenderTile.Wall12,
-        ObjectRenderTile.Wall13,
-        ObjectRenderTile.Wall14,
-        ObjectRenderTile.Wall15 -> true
+    private fun ObjectEntityTile.isWall(): Boolean = when (this) {
+        ObjectEntityTile.Wall -> true
         else -> false
     }
 

--- a/app/src/main/java/ru/meatgames/tomb/screen/compose/RoomRenderer.kt
+++ b/app/src/main/java/ru/meatgames/tomb/screen/compose/RoomRenderer.kt
@@ -3,7 +3,7 @@ package ru.meatgames.tomb.screen.compose
 import android.graphics.Bitmap
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -21,55 +21,55 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import ru.meatgames.tomb.design.h2TextStyle
-import ru.meatgames.tomb.domain.render.RoomPreviewRenderProcessor
+import ru.meatgames.tomb.domain.render.RoomPreviewRenderDataAssembler
 import ru.meatgames.tomb.model.room.data.RoomsRepository
 import ru.meatgames.tomb.model.theme.ThemeAssets
 import ru.meatgames.tomb.render.MapRenderTile
 import ru.meatgames.tomb.render.WallsDecorator
 import ru.meatgames.tomb.domain.map.MapTile
-import ru.meatgames.tomb.domain.map.MapTileWrapper
+import ru.meatgames.tomb.domain.render.BufferHolderFactory
 import ru.meatgames.tomb.model.theme.ASSETS_TILE_DIMENSION
 import ru.meatgames.tomb.model.theme.ASSETS_TILE_SIZE
 import kotlin.math.max
 
 @Preview
 @Composable
-private fun RoomRenderer() {
+private fun RoomRendererPreview() {
     val context = LocalContext.current
 
     val roomsData = RoomsRepository(context).loadData()
-    val mapRenderProcessor = RoomPreviewRenderProcessor(
-        themeAssets = ThemeAssets(context),
-        mapDecorators = setOf(WallsDecorator()),
-    )
-
     val room = roomsData.rooms.random()
 
-    val mapTiles = (0 until room.width * room.height).map { index ->
-        MapTileWrapper(
-            x = index % room.width,
-            y = index % room.height,
-            tile = MapTile(
-                floorEntityTile = roomsData.floorMapping
-                    .first { it.symbol == room.floor[index].toString() }
-                    .entity,
-                objectEntityTile = roomsData.objectMapping
-                    .first { it.symbol == room.objects[index].toString() }
-                    .let { it.entity },
-            ),
+    val bufferHolderFactory = BufferHolderFactory()
+    val bufferHolder = bufferHolderFactory.get(room.width, room.height)
+    val previewRenderDataAssembler = RoomPreviewRenderDataAssembler(
+        themeAssets = ThemeAssets(context),
+        bufferHolder = bufferHolder,
+        mapDecorators = setOf(
+            WallsDecorator(
+                bufferHolderFactory = bufferHolderFactory,
+            )
+        ),
+    )
+
+    val tiles = (0 until room.width * room.height).map { index ->
+        MapTile(
+            floorEntityTile = roomsData.floorMapping
+                .first { it.symbol == room.floor[index].toString() }
+                .entity,
+            objectEntityTile = roomsData.objectMapping
+                .first { it.symbol == room.objects[index].toString() }
+                .entity,
         )
     }
 
-    val renderTiles = mapRenderProcessor.produceRenderTilesFrom(
-        tiles = mapTiles,
-        tilesLineWidth = room.width,
-    ).map { it.second }
+    previewRenderDataAssembler.run(tiles)
 
     val roomPreviewData = RoomPreviewData(
         roomName = room.name,
         roomWidth = room.width,
         roomHeight = room.height,
-        tiles = renderTiles,
+        tiles = bufferHolder.resultRenderingBuffer.toList(),
         outerWalls = room.outerWalls,
     )
 
@@ -82,7 +82,7 @@ private fun RoomRenderer() {
 private fun RoomRenderer(
     roomPreviewData: RoomPreviewData,
     renderType: RoomRenderType = RoomRenderType.Full,
-) = BoxWithConstraints(
+) = Box(
     modifier = Modifier
         .background(Color(0xFF212121))
         .fillMaxSize(),
@@ -99,7 +99,8 @@ private fun RoomRenderer(
     }
     
     Text(
-        modifier = Modifier.fillMaxWidth()
+        modifier = Modifier
+            .fillMaxWidth()
             .padding(top = 48.dp)
             .padding(horizontal = 24.dp),
         text = roomPreviewData.roomName,

--- a/app/src/main/java/ru/meatgames/tomb/screen/compose/game/animation/AnimationConsts.kt
+++ b/app/src/main/java/ru/meatgames/tomb/screen/compose/game/animation/AnimationConsts.kt
@@ -7,7 +7,7 @@ const val ANIMATION_DURATION_MILLIS = 300
 
 //region Attack
 /**
- * Distance modifier for attack animation - mutliplied by tile size
+ * Distance modifier for attack animation - multiplied by tile size
  */
 const val ATTACK_DISTANCE_MODIFIER = .2f
 const val ENEMIES_ATTACK_DURATION_MILLIS = ANIMATION_DURATION_MILLIS

--- a/app/src/main/java/ru/meatgames/tomb/screen/compose/game/component/GameScreenPreviewData.kt
+++ b/app/src/main/java/ru/meatgames/tomb/screen/compose/game/component/GameScreenPreviewData.kt
@@ -4,7 +4,6 @@ import ru.meatgames.tomb.domain.component.HealthComponent
 import ru.meatgames.tomb.domain.enemy.EnemyType
 import ru.meatgames.tomb.domain.enemy.produceEnemy
 import ru.meatgames.tomb.domain.map.MapScreenState
-import ru.meatgames.tomb.domain.render.hasBottomShadow
 import ru.meatgames.tomb.model.theme.ASSETS_TILE_SIZE
 import ru.meatgames.tomb.model.theme.ThemeAssets
 import ru.meatgames.tomb.model.tile.domain.FloorRenderTile
@@ -62,7 +61,11 @@ internal fun gameScreenMapContainerPreviewRenderTiles(
         val objectData = tilesPair.second?.let {
             themeAssets.resolveObjectRenderData(it)
         }
-        val tileAbove = renderTiles.getOrNull(index - gameScreenMapContainerPreviewMapSize)
+        val hasShadow = renderTiles.getOrNull(index - gameScreenMapContainerPreviewMapSize)
+            ?.first
+            ?.javaClass
+            ?.name
+            ?.contains(Regex(".*Wall.*|.*Door.*|.*Stairs.*")) == true
         MapRenderTile.Content(
             floorData = RenderData(
                 asset = floorData.first,
@@ -79,10 +82,7 @@ internal fun gameScreenMapContainerPreviewRenderTiles(
             itemData = items[index],
             enemyData = enemies[index],
             isVisible = true,
-            decorations = tileAbove?.second
-                ?.takeIf { it.hasBottomShadow() }
-                ?.let { listOf(themeAssets.resolveBottomShadow()) }
-                ?: emptyList(),
+            decorations = if (hasShadow) listOf(themeAssets.resolveBottomShadow()) else emptyList(),
         )
     }
 }


### PR DESCRIPTION
The current implementation of the "rendering pipeline" is needlessly convoluted by using too much abstraction. In order to simplify it the redundant OOP parts were migrated to the standard concepts from the game development - buffers.

Now, a set of static buffers are allocated and reused during the lifecycle. They are filled with the appropriate data when it becomes available. It allows for easy use of any accumulated data during the "rendering pipeline" while removing code duplication and redundant local logic.