### PR TITLE
[TECH] Fix flickering tiles

### DIFF
--- a/app/src/main/java/ru/meatgames/tomb/domain/map/MapScreenController.kt
+++ b/app/src/main/java/ru/meatgames/tomb/domain/map/MapScreenController.kt
@@ -114,10 +114,10 @@ class MapScreenController @Inject constructor(
 
         val bufferHolder = bufferHolderFactory.get(viewportWidth, viewportHeight)
 
-        bufferHolder.clear()
-
-        bufferHolder.horizontalOffset = characterState.position.x - bufferHolder.horizontalCenter
-        bufferHolder.verticalOffset = characterState.position.y - bufferHolder.verticalCenter
+        bufferHolder.refresh(
+            horizontalOffset = characterState.position.x - bufferHolder.horizontalCenter,
+            verticalOffset = characterState.position.y - bufferHolder.verticalCenter
+        )
 
         bufferHolder.fillMapBuffer(
             tiles = this,

--- a/app/src/main/java/ru/meatgames/tomb/domain/render/BufferHolder.kt
+++ b/app/src/main/java/ru/meatgames/tomb/domain/render/BufferHolder.kt
@@ -9,6 +9,8 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 const val BUFFER_SIZE_MODIFIER: Int = 1
+private const val BUFFER_AMOUNT: Int = 2
+private const val DEFAULT_OFFSET = Int.MAX_VALUE
 
 class BufferHolder(
     viewportWidth: Int,
@@ -23,23 +25,62 @@ class BufferHolder(
 
     private val size: Int = width * height
 
-    var horizontalOffset: Int = 0
-    var verticalOffset: Int = 0
+    var horizontalOffset: Int = DEFAULT_OFFSET
+        private set
+    var verticalOffset: Int = DEFAULT_OFFSET
+        private set
     val offset: Coordinates
         get() = horizontalOffset to verticalOffset
+
+    var horizontalMotion: Int = 0
+        private set
+    var verticalMotion: Int = 0
+        private set
+
+    private var bufferCounter: Int = 0
+    private val bufferIndex: Int
+        get() = bufferCounter % BUFFER_AMOUNT
 
     val mapBuffer: Array<MapTile?> = Array(size) { null }
     val visibilityBuffer: BooleanArray = BooleanArray(size) { false }
     val floorRenderingBuffer: Array<FloorRenderTile?> = Array(size) { null }
     val objectRenderingBuffer: Array<ObjectRenderTile?> = Array(size) { null }
-    val resultRenderingBuffer: Array<MapRenderTile> = Array(size) { MapRenderTile.Empty }
+    private val _resultRenderingBuffer: Array<Array<MapRenderTile>> =
+        Array(BUFFER_AMOUNT) { Array(size) { MapRenderTile.Empty } }
 
-    fun clear() {
+    val resultRenderingBuffer: Array<MapRenderTile>
+        get() = _resultRenderingBuffer[bufferIndex]
+
+    fun refresh(
+        horizontalOffset: Int,
+        verticalOffset: Int,
+    ) {
+        if (this.horizontalOffset != DEFAULT_OFFSET && this.verticalOffset != DEFAULT_OFFSET) {
+            horizontalMotion = horizontalOffset - this.horizontalOffset
+            verticalMotion = verticalOffset - this.verticalOffset
+        }
+
+        this.horizontalOffset = horizontalOffset
+        this.verticalOffset = verticalOffset
+
+        bufferCounter++
+
         mapBuffer.fill(null)
         visibilityBuffer.fill(true)
         floorRenderingBuffer.fill(null)
         objectRenderingBuffer.fill(null)
         resultRenderingBuffer.fill(MapRenderTile.Empty)
+    }
+
+    fun replaceWithPreviousResultRenderingBuffer(
+        index: Int,
+    ) {
+        val adjustedIndex = index + horizontalMotion + verticalMotion * width
+        _resultRenderingBuffer[(bufferIndex + 1) % BUFFER_AMOUNT]
+            .getOrNull(adjustedIndex)
+            ?.let {
+                resultRenderingBuffer[index] = it
+            }
     }
 
 }
@@ -60,7 +101,7 @@ class BufferHolderFactory @Inject constructor() {
         viewportHeight: Int,
     ): BufferHolder {
         return _cachedBufferHolder
-            ?.takeIf { viewportWidth + BUFFER_SIZE_MODIFIER == it.width && viewportHeight + BUFFER_SIZE_MODIFIER == it.height }
+            ?.takeIf { viewportWidth + BUFFER_SIZE_MODIFIER * 2 == it.width && viewportHeight + BUFFER_SIZE_MODIFIER * 2 == it.height }
             ?: let { BufferHolder(viewportWidth, viewportHeight).also { _cachedBufferHolder = it } }
     }
 

--- a/app/src/main/java/ru/meatgames/tomb/domain/render/GameMapRenderPipeline.kt
+++ b/app/src/main/java/ru/meatgames/tomb/domain/render/GameMapRenderPipeline.kt
@@ -41,21 +41,22 @@ class GameMapRenderPipeline @Inject constructor(
 
             val x = index % bufferHolder.width
             val y = index / bufferHolder.width
-            val coordinates =
+            val mapCoordinates =
                 (bufferHolder.horizontalOffset + x) to (bufferHolder.verticalOffset + y)
+            val bufferCoordinates = x to y
 
-            val previousTileWasVisible = previousVisibleTiles.contains(coordinates)
+            val previousTileWasVisible = previousVisibleTiles.contains(mapCoordinates)
             val currentTileVisible = mapRenderTile.isVisible
 
             if (previousTileWasVisible && !currentTileVisible) {
-                tilesToFade.add(coordinates)
+                tilesToFade.add(bufferCoordinates)
             }
             if (!previousTileWasVisible && currentTileVisible) {
-                tilesToReveal.add(coordinates)
+                tilesToReveal.add(bufferCoordinates)
             }
 
             if (currentTileVisible) {
-                previousTiles.add(coordinates)
+                previousTiles.add(mapCoordinates)
             }
         }
 

--- a/app/src/main/java/ru/meatgames/tomb/domain/render/GameMapRenderPipeline.kt
+++ b/app/src/main/java/ru/meatgames/tomb/domain/render/GameMapRenderPipeline.kt
@@ -50,6 +50,7 @@ class GameMapRenderPipeline @Inject constructor(
 
             if (previousTileWasVisible && !currentTileVisible) {
                 tilesToFade.add(bufferCoordinates)
+                bufferHolder.replaceWithPreviousResultRenderingBuffer(index)
             }
             if (!previousTileWasVisible && currentTileVisible) {
                 tilesToReveal.add(bufferCoordinates)

--- a/app/src/main/java/ru/meatgames/tomb/render/WallsDecorator.kt
+++ b/app/src/main/java/ru/meatgames/tomb/render/WallsDecorator.kt
@@ -18,7 +18,6 @@ class WallsDecorator @Inject constructor(
         bufferHolder.mapBuffer.iterator().forEach { tile ->
             index++
 
-            if (!bufferHolder.visibilityBuffer[index]) return@forEach
             val objectEntityTile = tile?.objectEntityTile ?: return@forEach
             if (!objectEntityTile.isWall()) return@forEach
 

--- a/app/src/main/java/ru/meatgames/tomb/screen/compose/game/component/GameScreenEnemies.kt
+++ b/app/src/main/java/ru/meatgames/tomb/screen/compose/game/component/GameScreenEnemies.kt
@@ -81,10 +81,10 @@ internal fun GameScreenEnemies(
                 ?.enemyId
                 ?.let { index to mapRenderTile }
         }.forEach { (index, renderTile) ->
-            val tileScreenSpaceCoordinates = (index % tilesWidth - tilesPadding) to (index / tilesWidth - tilesPadding)
+            val tileScreenSpaceCoordinates = (index % tilesWidth) to (index / tilesWidth)
             val tileOffset = IntOffset(
-                tileScreenSpaceCoordinates.first * tileDimension,
-                tileScreenSpaceCoordinates.second * tileDimension,
+                (tileScreenSpaceCoordinates.first - tilesPadding) * tileDimension,
+                (tileScreenSpaceCoordinates.second - tilesPadding) * tileDimension,
             )
             
             val enemyId = renderTile.enemyData!!.enemyId
@@ -100,9 +100,9 @@ internal fun GameScreenEnemies(
             
             when {
                 animationAlpha != null -> animationAlpha
-                renderTile.isVisible && tilesToReveal.contains(tileScreenSpaceCoordinates) -> revealedTilesAlpha
-                renderTile.isVisible -> 1f
+                tilesToReveal.contains(tileScreenSpaceCoordinates) -> revealedTilesAlpha
                 tilesToFade.contains(tileScreenSpaceCoordinates) -> fadedTilesAlpha
+                renderTile.isVisible -> 1f
                 else -> null
             }?.let { alpha ->
                 drawCharacter(

--- a/app/src/main/java/ru/meatgames/tomb/screen/compose/game/component/GameScreenMap.kt
+++ b/app/src/main/java/ru/meatgames/tomb/screen/compose/game/component/GameScreenMap.kt
@@ -77,10 +77,10 @@ internal fun GameScreenMap(
     
     Canvas(modifier = modifier) {
         tiles.forEachIndexed { index, renderTile ->
-            val tileScreenSpaceCoordinates = (index % tilesWidth - tilesPadding) to (index / tilesWidth - tilesPadding)
+            val tileScreenSpaceCoordinates = (index % tilesWidth) to (index / tilesWidth)
             val tileOffset = IntOffset(
-                tileScreenSpaceCoordinates.first * tileDimension,
-                tileScreenSpaceCoordinates.second * tileDimension,
+                (tileScreenSpaceCoordinates.first - tilesPadding) * tileDimension,
+                (tileScreenSpaceCoordinates.second - tilesPadding) * tileDimension,
             )
             
             val dstOffset = baseOffset + tileOffset

--- a/app/src/main/java/ru/meatgames/tomb/screen/compose/game/component/GameScreenMap.kt
+++ b/app/src/main/java/ru/meatgames/tomb/screen/compose/game/component/GameScreenMap.kt
@@ -89,14 +89,14 @@ internal fun GameScreenMap(
                 renderTile !is MapRenderTile.Content -> {
                     null
                 }
-                renderTile.isVisible && tilesToReveal.contains(tileScreenSpaceCoordinates) -> {
+                tilesToReveal.contains(tileScreenSpaceCoordinates) -> {
                     renderTile to revealedTilesAlpha
-                }
-                renderTile.isVisible -> {
-                    renderTile to 1f
                 }
                 tilesToFade.contains(tileScreenSpaceCoordinates) -> {
                     renderTile to fadedTilesAlpha
+                }
+                renderTile.isVisible -> {
+                    renderTile to 1f
                 }
                 else -> null
             }?.let { (tile, alpha) ->


### PR DESCRIPTION
Fixing some inconsistencies after the migration to the buffers:
- Fixed issue with WallsDecorator - the hidden tiles weren't processed
- Implemented double buffering to have the access to the previous state
- Fixed enemies fade animations 